### PR TITLE
Fixes to the template to make it work with OCP 3.9 and 3.11

### DIFF
--- a/openshift-cicd-flask-mongo/OpenShift/templates/dev-todo-app-flask-mongo-gogs.json
+++ b/openshift-cicd-flask-mongo/OpenShift/templates/dev-todo-app-flask-mongo-gogs.json
@@ -143,7 +143,7 @@
   ],
   "objects": [
     {
-      "apiVersion": "v1",
+      "apiVersion": "authorization.openshift.io/v1",
       "groupNames": null,
       "kind": "RoleBinding",
       "metadata": {
@@ -186,7 +186,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${MONGODB_APPLICATION_NAME}",
         "labels": {
@@ -323,7 +323,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${APPLICATION_NAME}"
       },
@@ -337,7 +337,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${APPLICATION_NAME}",
         "labels": {
@@ -391,7 +391,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${APPLICATION_NAME}",
         "labels": {
@@ -515,7 +515,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "metadata": {
         "name": "${APPLICATION_NAME}",
         "labels": {
@@ -591,7 +591,7 @@
       }
     },
     {
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "kind": "Route",
       "metadata": {
         "annotations": {
@@ -610,7 +610,7 @@
       }
     },
     {
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "kind": "ImageStream",
       "metadata": {
         "name": "gogs",
@@ -636,7 +636,7 @@
       }
     },
     {
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "kind": "DeploymentConfig",
       "metadata": {
         "labels": {
@@ -709,10 +709,6 @@
                   {
                     "name": "gogs-data",
                     "mountPath": "/opt/gogs/data"
-                  },
-                  {
-                    "name": "gogs-config",
-                    "mountPath": "/etc/gogs/conf"
                   }
                 ]
               }
@@ -721,18 +717,6 @@
               {
                 "name": "gogs-data",
                 "emptyDir": {}
-              },
-              {
-                "name": "gogs-config",
-                "configMap": {
-                  "name": "gogs-config",
-                  "items": [
-                    {
-                      "key": "app.ini",
-                      "path": "app.ini"
-                    }
-                  ]
-                }
               }
             ],
             "dnsPolicy": "ClusterFirst",
@@ -763,7 +747,7 @@
       "status": {}
     },
     {
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "kind": "DeploymentConfig",
       "metadata": {
         "creationTimestamp": null,
@@ -920,12 +904,12 @@
             "image": "docker.io/openshiftdemos/oc",
             "command": [
               "/bin/bash",
-              "/tmp/installgogs.sh"
+              "/tmp/install/installgogs.sh"
             ],
             "volumeMounts": [
               {
                 "name": "gogs-install",
-                "mountPath": "/tmp/"
+                "mountPath": "/tmp/install"
               }
             ],
             "resources": {
@@ -966,20 +950,10 @@
       "apiVersion": "v1",
       "kind": "ConfigMap",
       "metadata": {
-        "name": "gogs-config"
-      },
-      "data": {
-        "app.ini": "RUN_MODE = prod\nRUN_USER = gogs\n\n[security]\nINSTALL_LOCK = false\n\n[repository]\nROOT = /opt/gogs/data/repositories\n\n[webhook]\nSKIP_TLS_VERIFY = true\n"
-      }
-    },
-    {
-      "apiVersion": "v1",
-      "kind": "ConfigMap",
-      "metadata": {
         "name": "gogs-install"
       },
       "data": {
-        "installgogs.sh": "#!/bin/bash\n\nset -x\n\n# Use the oc client to get the url for the gogs route and service\nGOGSSVC=$(oc get svc gogs -o template --template='{{.spec.clusterIP}}')\nGOGSROUTE=$(oc get route gogs -o template --template='{{.spec.host}}')\n\n# Use the oc client to get the postgres variables into the current shell\neval $(oc env dc/postgresql-gogs --list | grep -v \\#)\n\n# postgres has a readiness probe, so checking if there is at least one\n# endpoint means postgres is alive and ready, so we can then attempt to install gogs\n# we're willing to wait 60 seconds for it, otherwise something is wrong.\nx=1\noc get ep postgresql-gogs -o yaml | grep \"\\- addresses:\"\nwhile [ ! $? -eq 0 ]\ndo\n  sleep 10\n  x=$(( $x + 1 ))\n\n  if [ $x -gt 100 ]\n  then\n    exit 255\n  fi\n\n  oc get ep postgresql-gogs -o yaml | grep \"\\- addresses:\"\ndone\n\n# now we wait for gogs to be ready in the same way\nx=1\noc get ep gogs -o yaml | grep \"\\- addresses:\"\nwhile [ ! $? -eq 0 ]\ndo\n  sleep 10\n  x=$(( $x + 1 ))\n\n  if [ $x -gt 100 ]\n  then\n    exit 255\n  fi\n\n  oc get ep gogs -o yaml | grep \"\\- addresses:\"\ndone\n\n# we might catch the router before it's been updated, so wait just a touch\n# more\nsleep 10\n\nRETURN=$(curl -o /dev/null -sL --post302 -w \"%{http_code}\" http://$GOGSSVC:3000/install \\\n--form db_type=PostgreSQL \\\n--form db_host=postgresql-gogs:5432 \\\n--form db_user=gogs \\\n--form db_passwd=$POSTGRESQL_PASSWORD \\\n--form db_name=gogs \\\n--form ssl_mode=disable \\\n--form db_path=data/gogs.db \\\n--form \"app_name=Gogs: Go Git Service\" \\\n--form repo_root_path=/opt/gogs/data/repositories \\\n--form run_user=gogs \\\n--form domain=localhost \\\n--form ssh_port=22 \\\n--form http_port=3000 \\\n--form app_url=http://${GOGSROUTE}/ \\\n--form log_root_path=/opt/gogs/log \\\n--form admin_name=gogs \\\n--form admin_passwd=${GOGS_PASSWORD} \\\n--form admin_confirm_passwd=${GOGS_PASSWORD} \\\n--form admin_email=admin@gogs.com)\n\nif [ $RETURN != \"200\" ] && [ $RETURN != \"302\" ]\nthen\n  echo \"ERROR: Failed to initialize Gogs\"\n  exit 255\nfi\n\nsleep 10\n\n# import github repository\ncat <<EOF > /tmp/data.json\n{\n  \"clone_addr\": \"${GIT_URI}\",\n  \"uid\": 1,\n  \"repo_name\": \"${CONTEXT_DIR}\"\n}\nEOF\n\nRETURN=$(curl -o /dev/null -sL -w \"%{http_code}\" -H \"Content-Type: application/json\" \\\n-u gogs:${GOGS_PASSWORD} -X POST http://$GOGSSVC:3000/api/v1/repos/migrate -d @/tmp/data.json)\n\nif [ $RETURN != \"201\" ]\nthen\n  echo \"ERROR: Failed to imported openshift-cicd-flask-mongo GitHub repo\"\n  exit 255\nfi\n\nsleep 5\n\n# add webhook to Gogs to trigger pipeline on push\ncat <<EOF > /tmp/data.json\n{\n  \"type\": \"gogs\",\n  \"config\": {\n    \"url\": \"https://openshift.default.svc.cluster.local/oapi/v1/namespaces/${DEV_PROJECT}/buildconfigs/${APPLICATION_NAME}/webhooks/${GENERIC_TRIGGER_SECRET}/generic\",\n    \"content_type\": \"json\"\n  },\n  \"events\": [\n    \"push\"\n  ],\n  \"active\": true\n}\nEOF\n\nRETURN=$(curl -o /dev/null -sL -w \"%{http_code}\" -H \"Content-Type: application/json\" \\\n-u gogs:${GOGS_PASSWORD} -X POST http://$GOGSSVC:3000/api/v1/repos/gogs/openshift-cicd-flask-mongo/hooks -d @/tmp/data.json)\n\nif [ $RETURN != \"201\" ]\nthen\n  echo \"ERROR: Failed to set webhook\"\n  exit 255\nfi\n\n\nexport newgiturl=http://$(oc get svc gogs -o=jsonpath='{.spec.clusterIP}'):$(oc get svc gogs -o=jsonpath='{.spec.ports[].port}')/gogs/openshift-cicd-flask-mongo\n echo newgiturl=$newgiturl\nexport patchstr={\\\"spec\\\":{\\\"source\\\":{\\\"git\\\":{\\\"uri\\\":\\\"$newgiturl\\\"}}}}\necho $patchstr\noc patch bc todo-app-flask-mongo -p $patchstr\n\noc start-build todo-app-flask-mongo"
+        "installgogs.sh": "#!/bin/bash\n\nset -x\n\n# Use the oc client to get the url for the gogs route and service\nGOGSSVC=$(oc get svc gogs -o template --template='{{.spec.clusterIP}}')\nGOGSROUTE=$(oc get route gogs -o template --template='{{.spec.host}}')\n\n# Use the oc client to get the postgres variables into the current shell\neval $(oc env dc/postgresql-gogs --list | grep -v \\#)\n\n# postgres has a readiness probe, so checking if there is at least one\n# endpoint means postgres is alive and ready, so we can then attempt to install gogs\n# we're willing to wait 60 seconds for it, otherwise something is wrong.\nx=1\noc get ep postgresql-gogs -o yaml | grep \"\\- addresses:\"\nwhile [ ! $? -eq 0 ]\ndo\n  sleep 10\n  x=$(( $x + 1 ))\n\n  if [ $x -gt 100 ]\n  then\n    exit 255\n  fi\n\n  oc get ep postgresql-gogs -o yaml | grep \"\\- addresses:\"\ndone\n\n# now we wait for gogs to be ready in the same way\nx=1\noc get ep gogs -o yaml | grep \"\\- addresses:\"\nwhile [ ! $? -eq 0 ]\ndo\n  sleep 10\n  x=$(( $x + 1 ))\n\n  if [ $x -gt 100 ]\n  then\n    exit 255\n  fi\n\n  oc get ep gogs -o yaml | grep \"\\- addresses:\"\ndone\n\n# we might catch the router before it's been updated, so wait just a touch\n# more\nsleep 10\n\n#Modify the gogs main config file\nGOG_POD=$(oc get po -l app=gogs -l deploymentconfig=gogs -o jsonpath='{.items[0].metadata.name}')\noc exec ${GOG_POD} -- sed -i -e 's/SKIP_TLS_VERIFY[[:space:]]*=[[:space:]]*false/SKIP_TLS_VERIFY = true/' \\\n-e 's/INSTALL_LOCK[[:space:]]*=[[:space:]]*true/INSTALL_LOCK = false/' \\\n-e 's|^ROOT[[:space:]]*=|ROOT = /opt/gogs/data/repositories|' /etc/gogs/conf/app.ini\n\nRETURN=$(curl -o /dev/null -sL --post302 -w \"%{http_code}\" http://$GOGSSVC:3000/install \\\n--form db_type=PostgreSQL \\\n--form db_host=postgresql-gogs:5432 \\\n--form db_user=gogs \\\n--form db_passwd=$POSTGRESQL_PASSWORD \\\n--form db_name=gogs \\\n--form ssl_mode=disable \\\n--form db_path=data/gogs.db \\\n--form \"app_name=Gogs: Go Git Service\" \\\n--form repo_root_path=/opt/gogs/data/repositories \\\n--form run_user=gogs \\\n--form domain=localhost \\\n--form ssh_port=22 \\\n--form http_port=3000 \\\n--form app_url=http://${GOGSROUTE}/ \\\n--form log_root_path=/opt/gogs/log \\\n--form admin_name=gogs \\\n--form admin_passwd=${GOGS_PASSWORD} \\\n--form admin_confirm_passwd=${GOGS_PASSWORD} \\\n--form admin_email=admin@gogs.com)\n\nif [ $RETURN != \"200\" ] && [ $RETURN != \"302\" ]\nthen\n  echo \"ERROR: Failed to initialize Gogs\"\n  exit 255\nfi\n\nsleep 10\n\n# import github repository\ncat <<EOF > /tmp/data.json\n{\n  \"clone_addr\": \"${GIT_URI}\",\n  \"uid\": 1,\n  \"repo_name\": \"${CONTEXT_DIR}\"\n}\nEOF\n\nRETURN=$(curl -o /dev/null -sL -w \"%{http_code}\" -H \"Content-Type: application/json\" \\\n-u gogs:${GOGS_PASSWORD} -X POST http://$GOGSSVC:3000/api/v1/repos/migrate -d @/tmp/data.json)\n\nif [ $RETURN != \"201\" ]\nthen\n  echo \"ERROR: Failed to imported openshift-cicd-flask-mongo GitHub repo\"\n  exit 255\nfi\n\nsleep 5\n\n# add webhook to Gogs to trigger pipeline on push\ncat <<EOF > /tmp/data.json\n{\n  \"type\": \"gogs\",\n  \"config\": {\n    \"url\": \"https://openshift.default.svc.cluster.local/oapi/v1/namespaces/${DEV_PROJECT}/buildconfigs/${APPLICATION_NAME}/webhooks/${GENERIC_TRIGGER_SECRET}/generic\",\n    \"content_type\": \"json\"\n  },\n  \"events\": [\n    \"push\"\n  ],\n  \"active\": true\n}\nEOF\n\nRETURN=$(curl -o /dev/null -sL -w \"%{http_code}\" -H \"Content-Type: application/json\" \\\n-u gogs:${GOGS_PASSWORD} -X POST http://$GOGSSVC:3000/api/v1/repos/gogs/openshift-cicd-flask-mongo/hooks -d @/tmp/data.json)\n\nif [ $RETURN != \"201\" ]\nthen\n  echo \"ERROR: Failed to set webhook\"\n  exit 255\nfi\n\n\nexport newgiturl=http://$(oc get svc gogs -o=jsonpath='{.spec.clusterIP}'):$(oc get svc gogs -o=jsonpath='{.spec.ports[].port}')/gogs/openshift-cicd-flask-mongo\n echo newgiturl=$newgiturl\nexport patchstr={\\\"spec\\\":{\\\"source\\\":{\\\"git\\\":{\\\"uri\\\":\\\"$newgiturl\\\"}}}}\necho $patchstr\noc patch bc todo-app-flask-mongo -p $patchstr\n\noc start-build todo-app-flask-mongo"
       }
     }
   ]


### PR DESCRIPTION
Very good example in chapter 6, unfortunately it didn't work for me, so I decided to fix it.  The fixes have been tested and verified on OCP 3.9 and 3.11

Several apiVersion references in the resource definitions were corrected

gogs-config configMap removed because made /etc/gogs/conf directory read only and impossible to modify gogs configuration.  The same functionality is achieved with a sed command added to the gogs-install.sh script in gogs-install configMap:

       #Modify the gogs main config file
        GOG_POD=$(oc get po -l app=gogs -l deploymentconfig=gogs -o jsonpath='{.items[0].metadata.name}')
        oc exec ${GOG_POD} -- sed -i -e 's/SKIP_TLS_VERIFY[[:space:]]*=[[:space:]]*false/SKIP_TLS_VERIFY = true/' \
        -e 's/INSTALL_LOCK[[:space:]]*=[[:space:]]*true/INSTALL_LOCK = false/' \
        -e 's|^ROOT[[:space:]]*=|ROOT = /opt/gogs/data/repositories|' /etc/gogs/conf/app.ini

gogs-install configMap is mounted in /tmp/install to avoid making /tmp read only.
